### PR TITLE
Vector Approx matchers.

### DIFF
--- a/include/internal/catch_matchers_vector.h
+++ b/include/internal/catch_matchers_vector.h
@@ -9,6 +9,7 @@
 #define TWOBLUECUBES_CATCH_MATCHERS_VECTOR_H_INCLUDED
 
 #include "catch_matchers.h"
+#include "catch_approx.h"
 
 #include <algorithm>
 
@@ -113,6 +114,42 @@ namespace Matchers {
         };
 
         template<typename T>
+        struct ApproxMatcher : MatcherBase<std::vector<T>> {
+
+            ApproxMatcher(std::vector<T> const &comparator) : m_comparator( comparator ), approx{0.} {}
+
+            bool match(std::vector<T> const &v) const override {
+                if (m_comparator.size() != v.size())
+                    return false;
+                for (std::size_t i = 0; i < v.size(); ++i)
+                    if (m_comparator[i] != approx(v[i]))
+                        return false;
+                return true;
+            }
+            std::string describe() const override {
+                return "Equals: " + ::Catch::Detail::stringify( m_comparator );
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& epsilon( T const& newEpsilon ) {
+                approx.epsilon(newEpsilon);
+                return *this;
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& margin( T const& newMargin ) {
+                approx.margin(newMargin);
+                return *this;
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& scale( T const& newScale ) {
+                approx.scale(newScale);
+                return *this;
+            }
+
+            std::vector<T> const& m_comparator;
+            mutable ::Catch::Detail::Approx approx;
+        };
+
+        template<typename T>
         struct UnorderedEqualsMatcher : MatcherBase<std::vector<T>> {
             UnorderedEqualsMatcher(std::vector<T> const& target) : m_target(target) {}
             bool match(std::vector<T> const& vec) const override {
@@ -170,6 +207,11 @@ namespace Matchers {
     template<typename T>
     Vector::EqualsMatcher<T> Equals( std::vector<T> const& comparator ) {
         return Vector::EqualsMatcher<T>( comparator );
+    }
+
+    template<typename T>
+    Vector::ApproxMatcher<T> Approx( std::vector<T> const& comparator ) {
+        return Vector::ApproxMatcher<T>( comparator );
     }
 
     template<typename T>

--- a/projects/SelfTest/Baselines/compact.sw.approved.txt
+++ b/projects/SelfTest/Baselines/compact.sw.approved.txt
@@ -881,6 +881,10 @@ Matchers.tests.cpp:<line number>: passed: v, UnorderedEquals(v) for: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>: passed: empty, UnorderedEquals(empty) for: {  } UnorderedEquals: {  }
 Matchers.tests.cpp:<line number>: passed: permuted, UnorderedEquals(v) for: { 1, 3, 2 } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>: passed: permuted, UnorderedEquals(v) for: { 2, 3, 1 } UnorderedEquals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>: passed: v3, Catch::Approx(v3) for: { 1.0, 2.0, 3.0 } Equals: { 1.0, 2.0, 3.0 }
+Matchers.tests.cpp:<line number>: passed: v4, Catch::Approx(v4) for: { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.00000001, 2.00000001, 3.00000001 }
+Matchers.tests.cpp:<line number>: passed: v4, Catch::Approx(v3) for: { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.0, 2.0, 3.0 }
+Matchers.tests.cpp:<line number>: passed: v3, Catch::Approx(v4) for: { 1.0, 2.0, 3.0 } Equals: { 1.00000001, 2.00000001, 3.00000001 }
 Matchers.tests.cpp:<line number>: failed: v, VectorContains(-1) for: { 1, 2, 3 } Contains: -1
 Matchers.tests.cpp:<line number>: failed: empty, VectorContains(1) for: {  } Contains: 1
 Matchers.tests.cpp:<line number>: failed: empty, Contains(v) for: {  } Contains: { 1, 2, 3 }
@@ -893,6 +897,8 @@ Matchers.tests.cpp:<line number>: failed: v, UnorderedEquals(empty) for: { 1, 2,
 Matchers.tests.cpp:<line number>: failed: empty, UnorderedEquals(v) for: {  } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>: failed: permuted, UnorderedEquals(v) for: { 1, 3 } UnorderedEquals: { 1, 2, 3 }
 Matchers.tests.cpp:<line number>: failed: permuted, UnorderedEquals(v) for: { 3, 1 } UnorderedEquals: { 1, 2, 3 }
+Matchers.tests.cpp:<line number>: failed: v3, Catch::Approx(v4) for: { 1.0, 2.0, 3.0 } Equals: { 1.1, 2.1, 3.1 }
+Matchers.tests.cpp:<line number>: failed: v4, Catch::Approx(v3) for: { 1.1, 2.1, 3.1 } Equals: { 1.0, 2.0, 3.0 }
 Exception.tests.cpp:<line number>: passed: thisThrows(), std::domain_error
 Exception.tests.cpp:<line number>: passed: thisDoesntThrow()
 Exception.tests.cpp:<line number>: passed: thisThrows()
@@ -1160,5 +1166,5 @@ Misc.tests.cpp:<line number>: passed: v.size() == 5 for: 5 == 5
 Misc.tests.cpp:<line number>: passed: v.capacity() >= 5 for: 5 >= 5
 Misc.tests.cpp:<line number>: passed:
 Misc.tests.cpp:<line number>: passed:
-Failed 62 test cases, failed 122 assertions.
+Failed 62 test cases, failed 124 assertions.
 

--- a/projects/SelfTest/Baselines/console.std.approved.txt
+++ b/projects/SelfTest/Baselines/console.std.approved.txt
@@ -847,6 +847,23 @@ with expansion:
   { 3, 1 } UnorderedEquals: { 1, 2, 3 }
 
 -------------------------------------------------------------------------------
+Vector matchers that fail
+  Approx
+-------------------------------------------------------------------------------
+Matchers.tests.cpp:<line number>
+...............................................................................
+
+Matchers.tests.cpp:<line number>: FAILED:
+  CHECK_THAT( v3, Catch::Approx(v4) )
+with expansion:
+  { 1.0, 2.0, 3.0 } Equals: { 1.1, 2.1, 3.1 }
+
+Matchers.tests.cpp:<line number>: FAILED:
+  CHECK_THAT( v4, Catch::Approx(v3) )
+with expansion:
+  { 1.1, 2.1, 3.1 } Equals: { 1.0, 2.0, 3.0 }
+
+-------------------------------------------------------------------------------
 When unchecked exceptions are thrown directly they are always failures
 -------------------------------------------------------------------------------
 Exception.tests.cpp:<line number>
@@ -1097,5 +1114,5 @@ due to unexpected exception with message:
 
 ===============================================================================
 test cases:  208 | 155 passed |  49 failed |  4 failed as expected
-assertions: 1081 | 952 passed | 108 failed | 21 failed as expected
+assertions: 1087 | 956 passed | 110 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/console.sw.approved.txt
+++ b/projects/SelfTest/Baselines/console.sw.approved.txt
@@ -6880,6 +6880,38 @@ with expansion:
   { 2, 3, 1 } UnorderedEquals: { 1, 2, 3 }
 
 -------------------------------------------------------------------------------
+Vector matchers
+  Approx
+-------------------------------------------------------------------------------
+Matchers.tests.cpp:<line number>
+...............................................................................
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  CHECK_THAT( v3, Catch::Approx(v3) )
+with expansion:
+  { 1.0, 2.0, 3.0 } Equals: { 1.0, 2.0, 3.0 }
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  CHECK_THAT( v4, Catch::Approx(v4) )
+with expansion:
+  { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.00000001, 2.00000001, 3.
+  00000001 }
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( v4, Catch::Approx(v3) )
+with expansion:
+  { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.0, 2.0, 3.0 }
+
+Matchers.tests.cpp:<line number>:
+PASSED:
+  REQUIRE_THAT( v3, Catch::Approx(v4) )
+with expansion:
+  { 1.0, 2.0, 3.0 } Equals: { 1.00000001, 2.00000001, 3.00000001 }
+
+-------------------------------------------------------------------------------
 Vector matchers that fail
   Contains (element)
 -------------------------------------------------------------------------------
@@ -6966,6 +6998,23 @@ Matchers.tests.cpp:<line number>: FAILED:
   CHECK_THAT( permuted, UnorderedEquals(v) )
 with expansion:
   { 3, 1 } UnorderedEquals: { 1, 2, 3 }
+
+-------------------------------------------------------------------------------
+Vector matchers that fail
+  Approx
+-------------------------------------------------------------------------------
+Matchers.tests.cpp:<line number>
+...............................................................................
+
+Matchers.tests.cpp:<line number>: FAILED:
+  CHECK_THAT( v3, Catch::Approx(v4) )
+with expansion:
+  { 1.0, 2.0, 3.0 } Equals: { 1.1, 2.1, 3.1 }
+
+Matchers.tests.cpp:<line number>: FAILED:
+  CHECK_THAT( v4, Catch::Approx(v3) )
+with expansion:
+  { 1.1, 2.1, 3.1 } Equals: { 1.0, 2.0, 3.0 }
 
 -------------------------------------------------------------------------------
 When checked exceptions are thrown they can be expected or unexpected
@@ -9153,5 +9202,5 @@ PASSED:
 
 ===============================================================================
 test cases:  208 | 142 passed |  62 failed |  4 failed as expected
-assertions: 1095 | 952 passed | 122 failed | 21 failed as expected
+assertions: 1101 | 956 passed | 124 failed | 21 failed as expected
 

--- a/projects/SelfTest/Baselines/junit.sw.approved.txt
+++ b/projects/SelfTest/Baselines/junit.sw.approved.txt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuitesloose text artifact
 >
-  <testsuite name="<exe-name>" errors="17" failures="106" tests="1096" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
+  <testsuite name="<exe-name>" errors="17" failures="108" tests="1102" hostname="tbd" time="{duration}" timestamp="{iso8601-timestamp}">
     <testcase classname="<exe-name>.global" name="# A test name that starts with a #" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1005: Comparing pointer to int and long (NULL can be either on various systems)" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="#1027" time="{duration}"/>
@@ -622,6 +622,7 @@ Exception.tests.cpp:<line number>
     <testcase classname="<exe-name>.global" name="Vector matchers/Contains (element), composed" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector matchers/Equals" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector matchers/UnorderedEquals" time="{duration}"/>
+    <testcase classname="<exe-name>.global" name="Vector matchers/Approx" time="{duration}"/>
     <testcase classname="<exe-name>.global" name="Vector matchers that fail/Contains (element)" time="{duration}">
       <failure message="{ 1, 2, 3 } Contains: -1" type="CHECK_THAT">
 Matchers.tests.cpp:<line number>
@@ -663,6 +664,14 @@ Matchers.tests.cpp:<line number>
 Matchers.tests.cpp:<line number>
       </failure>
       <failure message="{ 3, 1 } UnorderedEquals: { 1, 2, 3 }" type="CHECK_THAT">
+Matchers.tests.cpp:<line number>
+      </failure>
+    </testcase>
+    <testcase classname="<exe-name>.global" name="Vector matchers that fail/Approx" time="{duration}">
+      <failure message="{ 1.0, 2.0, 3.0 } Equals: { 1.1, 2.1, 3.1 }" type="CHECK_THAT">
+Matchers.tests.cpp:<line number>
+      </failure>
+      <failure message="{ 1.1, 2.1, 3.1 } Equals: { 1.0, 2.0, 3.0 }" type="CHECK_THAT">
 Matchers.tests.cpp:<line number>
       </failure>
     </testcase>

--- a/projects/SelfTest/Baselines/xml.sw.approved.txt
+++ b/projects/SelfTest/Baselines/xml.sw.approved.txt
@@ -7795,6 +7795,41 @@ Message from section two
         </Expression>
         <OverallResults successes="4" failures="0" expectedFailures="0"/>
       </Section>
+      <Section name="Approx" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+        <Expression success="true" type="CHECK_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v3, Catch::Approx(v3)
+          </Original>
+          <Expanded>
+            { 1.0, 2.0, 3.0 } Equals: { 1.0, 2.0, 3.0 }
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="CHECK_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v4, Catch::Approx(v4)
+          </Original>
+          <Expanded>
+            { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.00000001, 2.00000001, 3.00000001 }
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v4, Catch::Approx(v3)
+          </Original>
+          <Expanded>
+            { 1.00000001, 2.00000001, 3.00000001 } Equals: { 1.0, 2.0, 3.0 }
+          </Expanded>
+        </Expression>
+        <Expression success="true" type="REQUIRE_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v3, Catch::Approx(v4)
+          </Original>
+          <Expanded>
+            { 1.0, 2.0, 3.0 } Equals: { 1.00000001, 2.00000001, 3.00000001 }
+          </Expanded>
+        </Expression>
+        <OverallResults successes="4" failures="0" expectedFailures="0"/>
+      </Section>
       <OverallResult success="true"/>
     </TestCase>
     <TestCase name="Vector matchers that fail" tags="[.][failing][matchers][vector]" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
@@ -7905,6 +7940,25 @@ Message from section two
           </Expanded>
         </Expression>
         <OverallResults successes="0" failures="4" expectedFailures="0"/>
+      </Section>
+      <Section name="Approx" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+        <Expression success="false" type="CHECK_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v3, Catch::Approx(v4)
+          </Original>
+          <Expanded>
+            { 1.0, 2.0, 3.0 } Equals: { 1.1, 2.1, 3.1 }
+          </Expanded>
+        </Expression>
+        <Expression success="false" type="CHECK_THAT" filename="projects/<exe-name>/UsageTests/Matchers.tests.cpp" >
+          <Original>
+            v4, Catch::Approx(v3)
+          </Original>
+          <Expanded>
+            { 1.1, 2.1, 3.1 } Equals: { 1.0, 2.0, 3.0 }
+          </Expanded>
+        </Expression>
+        <OverallResults successes="0" failures="2" expectedFailures="0"/>
       </Section>
       <OverallResult success="false"/>
     </TestCase>
@@ -10091,7 +10145,7 @@ loose text artifact
       </Section>
       <OverallResult success="true"/>
     </TestCase>
-    <OverallResults successes="952" failures="123" expectedFailures="21"/>
+    <OverallResults successes="956" failures="125" expectedFailures="21"/>
   </Group>
-  <OverallResults successes="952" failures="122" expectedFailures="21"/>
+  <OverallResults successes="956" failures="124" expectedFailures="21"/>
 </Catch>

--- a/projects/SelfTest/UsageTests/Matchers.tests.cpp
+++ b/projects/SelfTest/UsageTests/Matchers.tests.cpp
@@ -213,6 +213,16 @@ namespace { namespace MatchersTests {
             v2.push_back(1);
             v2.push_back(2);
 
+            std::vector<double> v3;
+            v3.push_back(1);
+            v3.push_back(2);
+            v3.push_back(3);
+            
+            std::vector<double> v4;
+            v4.push_back(1 + 1e-8);
+            v4.push_back(2 + 1e-8);
+            v4.push_back(3 + 1e-8);
+
             std::vector<int> empty;
 
             SECTION("Contains (element)") {
@@ -253,6 +263,13 @@ namespace { namespace MatchersTests {
                 std::reverse(begin(permuted), end(permuted));
                 REQUIRE_THAT(permuted, UnorderedEquals(v));
             }
+            SECTION("Approx") {
+                CHECK_THAT(v3, Catch::Approx(v3));
+                CHECK_THAT(v4, Catch::Approx(v4));
+
+                REQUIRE_THAT(v4, Catch::Approx(v3));
+                REQUIRE_THAT(v3, Catch::Approx(v4));
+            }
         }
 
         TEST_CASE("Vector matchers that fail", "[matchers][vector][.][failing]") {
@@ -264,6 +281,16 @@ namespace { namespace MatchersTests {
             std::vector<int> v2;
             v2.push_back(1);
             v2.push_back(2);
+
+            std::vector<double> v3;
+            v3.push_back(1);
+            v3.push_back(2);
+            v3.push_back(3);
+
+            std::vector<double> v4;
+            v4.push_back(1.1);
+            v4.push_back(2.1);
+            v4.push_back(3.1);
 
             std::vector<int> empty;
 
@@ -295,6 +322,11 @@ namespace { namespace MatchersTests {
 
                 std::reverse(begin(permuted), end(permuted));
                 CHECK_THAT(permuted, UnorderedEquals(v));
+            }
+            SECTION("Approx") {
+
+                CHECK_THAT(v3, Catch::Approx(v4));
+                CHECK_THAT(v4, Catch::Approx(v3));
             }
         }
 


### PR DESCRIPTION
<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, thats what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

In addition to Equals and UnorderedEquals, this PR implements an Approx matcher for std::vector<T>.

It is implemented along the lines of Equals and UnorderedEquals, with inspiration from previous attempts in issue #760, and [this StackOverflow discussion](https://stackoverflow.com/questions/41160846/test-floating-point-stdvector-with-c-catch)



## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Addresses #760